### PR TITLE
Fix the encoding error

### DIFF
--- a/HTMLParser.m
+++ b/HTMLParser.m
@@ -53,7 +53,7 @@
 		{
 			CFStringEncoding cfenc = CFStringConvertNSStringEncodingToEncoding(NSUTF8StringEncoding);
 			CFStringRef cfencstr = CFStringConvertEncodingToIANACharSetName(cfenc);
-			const char *enc = CFStringGetCStringPtr(cfencstr, 0);
+			const char *enc = [(__bridge NSString*)cfencstr UTF8String];//CFStringGetCStringPtr(cfencstr, 0);
 			// _doc = htmlParseDoc((xmlChar*)[string UTF8String], enc);
 			int optionsHtml = HTML_PARSE_RECOVER;
 			optionsHtml = optionsHtml | HTML_PARSE_NOERROR; //Uncomment this to see HTML errors
@@ -81,7 +81,7 @@
 		{
 			CFStringEncoding cfenc = CFStringConvertNSStringEncodingToEncoding(NSUTF8StringEncoding);
 			CFStringRef cfencstr = CFStringConvertEncodingToIANACharSetName(cfenc);
-			const char *enc = CFStringGetCStringPtr(cfencstr, 0);
+			const char *enc = [(__bridge NSString*)cfencstr UTF8String];//CFStringGetCStringPtr(cfencstr, 0);
 			//_doc = htmlParseDoc((xmlChar*)[data bytes], enc);
 			
 			_doc = htmlReadDoc((xmlChar*)[data bytes],


### PR DESCRIPTION
In some case, the encoding from the method CFStringGetCStringPtr come out "NULL" , It's very strange